### PR TITLE
🐛remove slugify

### DIFF
--- a/alie/cli.py
+++ b/alie/cli.py
@@ -21,7 +21,6 @@ from os import getenv
 import json
 
 import click
-import slugify
 
 from alie import __version__
 
@@ -117,7 +116,6 @@ def main(alias, command, is_function):
     Pass no arguments to list aliases. Pass only the `ALIAS` to remove it.
     """
     alie = Alie()
-    alias = slugify.slugify(alias or '', separator='_')
     colored = click.style(f'{alias}', fg='magenta')
 
     if not alias:

--- a/alie/cli.py
+++ b/alie/cli.py
@@ -116,6 +116,7 @@ def main(alias, command, is_function):
     Pass no arguments to list aliases. Pass only the `ALIAS` to remove it.
     """
     alie = Alie()
+    alias = '_'.join((alias or '').split(' '))
     colored = click.style(f'{alias}', fg='magenta')
 
     if not alias:

--- a/setup.json
+++ b/setup.json
@@ -18,8 +18,7 @@
         "pytest-runner==2.11.1"
     ],
     "install_requires": [
-        "Click>=6.7",
-        "python-slugify>=1.0.22"
+        "Click>=6.7"
     ],
     "extras_require": {
         "test": [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,11 @@ def test_main(tmpdir):
     result = runner.invoke(cli.main, params)
     assert 'CREATED' in result.output
 
+    params = [f'"clear console"', 'clear']
+    result = runner.invoke(cli.main, params)
+    assert 'CREATED' in result.output
+
     result = runner.invoke(cli.main, [])
     assert 'function ' in result.output
     assert 'say-message' in result.output
+    assert 'clear_console' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,7 @@
 """alie cli tests."""
 
-from click.testing import CliRunner
 from os import environ
-import pytest
+from click.testing import CliRunner
 
 from alie import cli
 
@@ -27,9 +26,10 @@ def test_main(tmpdir):
     result = runner.invoke(cli.main, ['hello'])
     assert 'not registered' in result.output
 
-    params = [f'say', 'echo "$@"', '-f']
+    params = [f'say-message', 'echo "$@"', '-f']
     result = runner.invoke(cli.main, params)
     assert 'CREATED' in result.output
 
     result = runner.invoke(cli.main, [])
     assert 'function ' in result.output
+    assert 'say-message' in result.output


### PR DESCRIPTION
Slugifying alias names is unnecessary. 

For example if a want to create alias such as these, they get converted into undesired names:
- `docker-stop-all` -> `docker_stop_all`
- `split_files.py` -> `split_files_py`

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] 🐛 &nbsp; Bug fix
- [ ] 🚀 &nbsp; New feature
- [ ] 🔧 &nbsp; Code refactor
- [ ] ⚠️ &nbsp; Breaking change that would cause existing functionality to change
- [ ] 📘 &nbsp; I have updated the documentation accordingly
- [x] ✅ &nbsp; I have added tests to cover my changes
